### PR TITLE
Fixes needed for Redmine 4 compatibility

### DIFF
--- a/app/controllers/issues_report_controller.rb
+++ b/app/controllers/issues_report_controller.rb
@@ -36,7 +36,7 @@ class IssuesReportController < ApplicationController
                               :order => sort_clause,
                               :offset => @offset,
                               :limit => @limit)
-      @issue_count_by_group = @query.issue_count_by_group           
+      @result_count_by_group = @query.result_count_by_group
     end
 
     respond_to do |format|

--- a/app/views/issues_report/report_list.html.erb
+++ b/app/views/issues_report/report_list.html.erb
@@ -54,7 +54,7 @@
     	rows.right l(:label_spent_time), (issue.total_spent_hours > 0 ? link_to(l_hours(issue.total_spent_hours), issue_time_entries_path(issue)) : "-"), :class => 'spent-time'
   	  end
 	end %>	
-	<%= render_custom_fields_rows(@issue) %>
+	<%= render_full_width_custom_fields_rows(@issue) %>
 	<%= call_hook(:view_issues_show_details_bottom, :issue => @issue) %>
 	
 	</div>


### PR DESCRIPTION
I found I needed to make a couple of changes to make this plugin work on Redmine 4.

```
Redmine version                4.0.4.stable
Ruby version                   2.5.3-p105 (2018-10-18) [x86_64-linux]
Rails version                  5.2.3
```

In issues_report_controller.rb, issue_count_by_group needed to be changed to result_count_by_group. According to [this](https://github.com/Restream/redmine_custom_reports/pull/41), issue_count_by_group was removed in Redmine 3.4.

In report_list.html.erb, render_custom_fields_rows needed to be changed to render_full_width_custom_fields_rows. It looks like this was also changed in Redmine 3.4 to implement [this change](http://www.redmine.org/issues/21705).